### PR TITLE
make packcheck.sh executable in diverse environments

### DIFF
--- a/packcheck.sh
+++ b/packcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #------------------------------------------------------------------------------
 # Skip to the end for main flow of script

--- a/packcheck.sh
+++ b/packcheck.sh
@@ -82,7 +82,7 @@ require_cmd () {
 # $1: command
 function run_verbose() {
   echo "$*"
-  /bin/bash -c "$*"
+  bash -c "$*"
 }
 
 function run_verbose_errexit() {
@@ -1087,7 +1087,7 @@ show_build_command
 TOOLS="awk cat curl cut date env head mkdir printf rm sleep tr which $OS_HAS_TOOLS"
 
 show_step "Check basic tools"
-require_cmd /bin/bash
+require_cmd bash
 for i in $TOOLS; do require_cmd $i; done
 
 show_step "Build host machine information"


### PR DESCRIPTION
The PR aims to solve the issue #3
tested:
- local `NixOS 17.09` OK.
- [travis ci run](https://travis-ci.org/p-alik/packcheck/builds/330446706) OK
